### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.0.1
+
+Patch release focused on Windows installer reliability and release verification.
+
+### Changed
+
+- Release builds now use a static CRT configuration so the shipped binaries do not depend on external VC++ runtime DLL installation.
+- Added a GitHub Actions installer validation workflow that covers NSIS build, winget manifest validation, silent install, command smoke tests, and uninstall on Windows.
+
+### Fixed
+
+- Removed the need for a separate VC++ runtime dependency to avoid clean-machine startup failures around `VCRUNTIME140.dll`.
+
 ## v1.0.0
 
 Initial v1.0 release for KBIntake, a Windows-friendly local vault import CLI and Explorer integration.

--- a/installer/kbintake.nsi
+++ b/installer/kbintake.nsi
@@ -6,7 +6,7 @@
 !define APP_EXE "kbintake.exe"
 !define APP_GUI_EXE "kbintakew.exe"
 !define APP_ICON "kbintake.ico"
-!define APP_VERSION "1.0.0"
+!define APP_VERSION "1.0.1"
 !define POWERSHELL_EXE "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
 
 Name "${APP_NAME}"

--- a/kbintake/Cargo.lock
+++ b/kbintake/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "kbintake"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -502,9 +502,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"

--- a/kbintake/Cargo.toml
+++ b/kbintake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbintake"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Windows-friendly CLI for right-click importing files into a local knowledge-base vault"
 


### PR DESCRIPTION
## Summary
- bump the crate and installer version to 1.0.1
- add changelog notes for the installer reliability patch release
- refresh Cargo.lock for the 1.0.1 package version

## Validation
- cargo test --locked
- cargo build --release --locked --bins --target x86_64-pc-windows-msvc
- makensis installer/kbintake.nsi
