### PR TITLE
Fix Codex review issues: COM command, object count, template persistence, nested watch

### DIFF
--- a/installer/kbintake.nsi
+++ b/installer/kbintake.nsi
@@ -44,7 +44,7 @@ Section "Install"
   ${EndIf}
 
   ; Register COM DLL for Windows 11 native context menu (requires admin for HKCR).
-  ExecWait '"$INSTDIR\${APP_COM_REG}" install --dll "$INSTDIR\${APP_COM_DLL}" --icon "$INSTDIR\${APP_ICON}"' $0
+  ExecWait '"$INSTDIR\${APP_COM_REG}" install --dll "$INSTDIR\${APP_COM_DLL}" --exe "$INSTDIR\${APP_EXE}" --icon "$INSTDIR\${APP_ICON}"' $0
   ${If} $0 != 0
     DetailPrint "COM registration returned $0; Win11 native menu can be registered later with kbintake-com-reg install."
   ${EndIf}

--- a/kbintake-com/src/bin/reg.rs
+++ b/kbintake-com/src/bin/reg.rs
@@ -21,6 +21,9 @@ enum Commands {
         /// Path to kbintake_com.dll
         #[arg(long)]
         dll: Option<PathBuf>,
+        /// Path to kbintake.exe (used for the fallback shell command)
+        #[arg(long)]
+        exe: Option<PathBuf>,
         /// Path to kbintake.ico for the context menu icon
         #[arg(long)]
         icon: Option<PathBuf>,
@@ -34,14 +37,14 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Install { dll, icon } => cmd_install(dll, icon),
+        Commands::Install { dll, exe, icon } => cmd_install(dll, exe, icon),
         Commands::Uninstall => cmd_uninstall(),
         Commands::Status => cmd_status(),
     }
 }
 
 #[cfg(windows)]
-fn cmd_install(dll: Option<PathBuf>, icon: Option<PathBuf>) {
+fn cmd_install(dll: Option<PathBuf>, exe: Option<PathBuf>, icon: Option<PathBuf>) {
     use winreg::enums::HKEY_CURRENT_USER;
     use winreg::RegKey;
 
@@ -50,6 +53,9 @@ fn cmd_install(dll: Option<PathBuf>, icon: Option<PathBuf>) {
         eprintln!("ERROR: DLL not found at {}", dll_path.display());
         std::process::exit(1);
     }
+
+    let exe_path = exe.unwrap_or_else(find_default_exe);
+    let exe_str = exe_path.to_string_lossy().to_string();
 
     // Always use HKCU — no admin required, visible through HKCR merged view.
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
@@ -113,13 +119,13 @@ fn cmd_install(dll: Option<PathBuf>, icon: Option<PathBuf>) {
             std::process::exit(1);
         }
     };
-    let _ = verb_cmd.set_value("", &format!("\"{}\" import --process \"%1\"", dll_str));
+    let _ = verb_cmd.set_value("", &format!("\"{}\" import --process \"%1\"", exe_str));
 
     println!("COM DLL registered (HKCU): {}", dll_path.display());
 }
 
 #[cfg(not(windows))]
-fn cmd_install(_dll: Option<PathBuf>, _icon: Option<PathBuf>) {
+fn cmd_install(_dll: Option<PathBuf>, _exe: Option<PathBuf>, _icon: Option<PathBuf>) {
     eprintln!("ERROR: COM registration is only supported on Windows");
     std::process::exit(1);
 }
@@ -201,6 +207,15 @@ fn find_default_dll() -> PathBuf {
         }
     }
     PathBuf::from("kbintake_com.dll")
+}
+
+fn find_default_exe() -> PathBuf {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            return parent.join("kbintake.exe");
+        }
+    }
+    PathBuf::from("kbintake.exe")
 }
 
 fn find_default_icon() -> PathBuf {

--- a/kbintake-com/src/command.rs
+++ b/kbintake-com/src/command.rs
@@ -99,6 +99,7 @@ unsafe extern "system" fn cmd_release(this: *mut c_void) -> u32 {
         - 1;
     if new_count == 0 {
         drop(Box::from_raw(this as *mut ExplorerCommandHandler));
+        crate::server::lock_count::object_release();
     }
     new_count
 }

--- a/kbintake/src/agent/watcher.rs
+++ b/kbintake/src/agent/watcher.rs
@@ -215,11 +215,13 @@ fn handle_event(debounce_map: &mut HashMap<PathBuf, DebounceTracker>, event: &Ev
 
     for path in &event.paths {
         if path.is_file() {
-            // Find the matching watch root and record the event.
-            for (root, tracker) in debounce_map.iter_mut() {
-                if path.starts_with(root) {
-                    tracker.record_event(path.clone());
-                }
+            // Find the most specific (longest) matching watch root and record the event.
+            if let Some((_, tracker)) = debounce_map
+                .iter_mut()
+                .filter(|(root, _)| path.starts_with(root))
+                .max_by_key(|(root, _)| root.as_os_str().len())
+            {
+                tracker.record_event(path.clone());
             }
         }
     }

--- a/kbintake/src/agent/worker.rs
+++ b/kbintake/src/agent/worker.rs
@@ -84,27 +84,43 @@ pub fn process_item(app: &App, item: ItemJob) -> Result<()> {
         })
         .unwrap_or_default();
 
-    let rendered_template: Result<Option<template::RenderedTemplate>> =
-        if let Some(template_config) = app.config.template_for_path(&source, size) {
-            let resolved =
-                template::resolve_template(&app.config.templates, &template_config.name)?;
-            Ok(Some(template::render_template(
-                &resolved,
-                &template::TemplateRenderContext {
-                    source_path: item.source_path.clone(),
-                    source_name: item.source_name.clone(),
-                    file_ext: item.file_ext.clone(),
-                    file_size_bytes: size,
-                    imported_at: chrono::Utc::now(),
-                    sha256: hash.clone(),
-                    target_name: target.name.clone(),
-                    batch_id: item.batch_id.clone(),
-                },
-                &cli_tags,
-            )))
-        } else {
-            Ok(None)
-        };
+    let rendered_template: Result<Option<template::RenderedTemplate>> = if let Some(explicit_name) =
+        &item.template_name
+    {
+        let resolved = template::resolve_template(&app.config.templates, explicit_name)?;
+        Ok(Some(template::render_template(
+            &resolved,
+            &template::TemplateRenderContext {
+                source_path: item.source_path.clone(),
+                source_name: item.source_name.clone(),
+                file_ext: item.file_ext.clone(),
+                file_size_bytes: size,
+                imported_at: chrono::Utc::now(),
+                sha256: hash.clone(),
+                target_name: target.name.clone(),
+                batch_id: item.batch_id.clone(),
+            },
+            &cli_tags,
+        )))
+    } else if let Some(template_config) = app.config.template_for_path(&source, size) {
+        let resolved = template::resolve_template(&app.config.templates, &template_config.name)?;
+        Ok(Some(template::render_template(
+            &resolved,
+            &template::TemplateRenderContext {
+                source_path: item.source_path.clone(),
+                source_name: item.source_name.clone(),
+                file_ext: item.file_ext.clone(),
+                file_size_bytes: size,
+                imported_at: chrono::Utc::now(),
+                sha256: hash.clone(),
+                target_name: target.name.clone(),
+                batch_id: item.batch_id.clone(),
+            },
+            &cli_tags,
+        )))
+    } else {
+        Ok(None)
+    };
     let rendered_template = match rendered_template {
         Ok(rendered_template) => rendered_template,
         Err(err) => {

--- a/kbintake/src/cli/mod.rs
+++ b/kbintake/src/cli/mod.rs
@@ -394,11 +394,12 @@ pub fn handle_import(
     ))?;
 
     let mut count = 0usize;
-    for (file, target, _) in routed_files {
+    for (file, target, template_name) in routed_files {
         let mut item = ItemJob::new(batch.batch_id.clone(), target.target_id.clone(), file);
         if !cli_tags.is_empty() {
             item.cli_tags = Some(cli_tags.join(","));
         }
+        item.template_name = template_name;
         repo.insert_item(&item)?;
         repo.insert_event(&DomainEvent::new(
             "item",

--- a/kbintake/src/db/mod.rs
+++ b/kbintake/src/db/mod.rs
@@ -4,14 +4,14 @@ use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use rusqlite::{params, Connection};
 
-const LATEST_SCHEMA_VERSION: i64 = 6;
+const LATEST_SCHEMA_VERSION: i64 = 7;
 
 struct Migration {
     version: i64,
     sql: &'static str,
 }
 
-const MIGRATIONS: [Migration; 6] = [
+const MIGRATIONS: [Migration; 7] = [
     Migration {
         version: 1,
         sql: schema::MIGRATION_001_CORE,
@@ -35,6 +35,10 @@ const MIGRATIONS: [Migration; 6] = [
     Migration {
         version: 6,
         sql: schema::MIGRATION_006_ITEM_IMPORT_SUBFOLDER,
+    },
+    Migration {
+        version: 7,
+        sql: schema::MIGRATION_007_ITEM_TEMPLATE_NAME,
     },
 ];
 
@@ -196,7 +200,7 @@ mod tests {
 
         let applied = apply_pending_migrations(&conn).unwrap();
 
-        assert_eq!(applied, vec![3, 4, 5, 6]);
+        assert_eq!(applied, vec![3, 4, 5, 6, 7]);
         assert_eq!(
             current_schema_version(&conn).unwrap(),
             latest_schema_version()

--- a/kbintake/src/db/schema.rs
+++ b/kbintake/src/db/schema.rs
@@ -85,3 +85,7 @@ ALTER TABLE items ADD COLUMN cli_tags TEXT;
 pub const MIGRATION_006_ITEM_IMPORT_SUBFOLDER: &str = r#"
 ALTER TABLE items ADD COLUMN import_subfolder TEXT;
 "#;
+
+pub const MIGRATION_007_ITEM_TEMPLATE_NAME: &str = r#"
+ALTER TABLE items ADD COLUMN template_name TEXT;
+"#;

--- a/kbintake/src/domain/item.rs
+++ b/kbintake/src/domain/item.rs
@@ -22,6 +22,7 @@ pub struct ItemJob {
     pub error_message: Option<String>,
     pub cli_tags: Option<String>,
     pub import_subfolder: Option<String>,
+    pub template_name: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -55,6 +56,7 @@ impl ItemJob {
             error_message: None,
             cli_tags: None,
             import_subfolder: None,
+            template_name: None,
             created_at: now,
             updated_at: now,
         }

--- a/kbintake/src/queue/repository.rs
+++ b/kbintake/src/queue/repository.rs
@@ -125,8 +125,8 @@ impl<'a> Repository<'a> {
             "INSERT INTO items (
                 item_id, batch_id, target_id, source_path, source_name, file_ext, status, stage,
                 source_size, sha256, stored_sha256, stored_path, duplicate_of, error_code, error_message,
-                cli_tags, import_subfolder, created_at, updated_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
+                cli_tags, import_subfolder, template_name, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             params![
                 &item.item_id,
                 &item.batch_id,
@@ -145,6 +145,7 @@ impl<'a> Repository<'a> {
                 item.error_message.as_deref(),
                 item.cli_tags.as_deref(),
                 item.import_subfolder.as_deref(),
+                item.template_name.as_deref(),
                 item.created_at.to_rfc3339(),
                 item.updated_at.to_rfc3339()
             ],
@@ -156,7 +157,7 @@ impl<'a> Repository<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT item_id, batch_id, target_id, source_path, source_name, file_ext, status, stage,
                     source_size, sha256, stored_sha256, stored_path, duplicate_of, error_code, error_message,
-                    cli_tags, import_subfolder, created_at, updated_at
+                    cli_tags, import_subfolder, template_name, created_at, updated_at
              FROM items WHERE batch_id = ?1 ORDER BY created_at ASC",
         )?;
         let rows = stmt.query_map(params![batch_id], row_to_item)?;
@@ -212,7 +213,7 @@ impl<'a> Repository<'a> {
             .query_row(
                 "SELECT item_id, batch_id, target_id, source_path, source_name, file_ext, status, stage,
                         source_size, sha256, stored_sha256, stored_path, duplicate_of, error_code, error_message,
-                        cli_tags, import_subfolder, created_at, updated_at
+                        cli_tags, import_subfolder, template_name, created_at, updated_at
                  FROM items WHERE status = ?1 ORDER BY created_at ASC LIMIT 1",
                 params![state_machine::STATUS_QUEUED],
                 row_to_item,
@@ -530,8 +531,9 @@ fn row_to_item(row: &rusqlite::Row<'_>) -> rusqlite::Result<ItemJob> {
         error_message: row.get(14)?,
         cli_tags: row.get(15)?,
         import_subfolder: row.get(16)?,
-        created_at: parse_utc(row.get(17)?)?,
-        updated_at: parse_utc(row.get(18)?)?,
+        template_name: row.get(17)?,
+        created_at: parse_utc(row.get(18)?)?,
+        updated_at: parse_utc(row.get(19)?)?,
     })
 }
 

--- a/kbintake/tests/mvp_flow.rs
+++ b/kbintake/tests/mvp_flow.rs
@@ -1270,7 +1270,7 @@ fn cli_doctor_fix_creates_missing_target_and_reports_checks() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("[OK] Config file"));
     assert!(stdout.contains("[OK] Database schema"));
-    assert!(stdout.contains("Schema version: 6 (up to date)"));
+    assert!(stdout.contains("Schema version: 7 (up to date)"));
     assert!(stdout.contains("[OK] Target directory"));
     assert!(app_data_dir.join("vault").exists());
 }
@@ -1312,7 +1312,7 @@ fn cli_doctor_migrate_flag_reports_schema_version() {
         .unwrap();
 
     assert_eq!(output.status.code(), Some(kbintake::exit_codes::SUCCESS));
-    assert!(String::from_utf8_lossy(&output.stdout).contains("Schema version: 6 (up to date)"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Schema version: 7 (up to date)"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fix COM reg tool fallback command to point to kbintake.exe instead of DLL
- Fix COM object reference counting (add object_release in cmd_release)
- Persist --template choice through queued processing (DB migration 007)
- Fix nested watch directories using longest-prefix matching

## Test plan

- [x] All 171 unit + integration tests pass
- [x] Clippy clean, formatting verified
- [x] COM DLL Validation CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)