### PR TITLE
Release v2.1.1: Codex review fixes and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.1.1 (2026-05-06)
+
+Patch release fixing issues found during code review.
+
+### Fixed
+
+- COM registration fallback command now points to `kbintake.exe` instead of the DLL, so the legacy "Show more options" context menu works correctly.
+- COM object reference counting: `DllCanUnloadNow` now correctly reports when the DLL can be unloaded.
+- `--template` choice is now persisted through queued processing (DB migration 007), so explicit template overrides survive queue-based imports.
+- Nested watch directories use longest-prefix matching to avoid duplicate file processing.
+
 ## v2.1.0 (2026-05-03)
 
 Patch release fixing CLI tag injection and adding optional tray auto-start to the installer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **KBIntake** is a Windows-first local vault importer CLI (Rust 2021). It imports files/folders into a knowledge-base vault via PowerShell or Windows Explorer right-click context menu, with SQLite-backed job history, SHA-256 deduplication, and toast notifications.
 
 - Current branch: `v2.0` (template system, routing v2, Watch Mode, Win11 native context menu, system tray)
-- Current release: `v2.1.0`
+- Current release: `v2.1.1`
 
 ## Build, Test, and Development Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "kbintake"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 KBIntake is a Windows-first local vault importer. It lets you send files and folders into a knowledge-base vault from PowerShell or from the Windows Explorer right-click menu, while keeping an auditable SQLite job history.
 
-Current release: `v2.1.0`
+Current release: `v2.1.1`
 
-- Download: <https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0>
+- Download: <https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1>
 - Chinese README: [README.zh-CN.md](README.zh-CN.md)
 
 ## What It Is For
@@ -23,7 +23,7 @@ KBIntake does not require a cloud service. Configuration, queue state, manifests
 
 ### Recommended
 
-1. Open the [v2.1.0 release page](https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0).
+1. Open the [v2.1.1 release page](https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1).
 2. Download `KBIntake-Setup.exe`.
 3. Run the installer.
 4. Open a new PowerShell window and run:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 KBIntake 是一个面向 Windows 的本地知识库导入工具。它可以把文件或文件夹从 PowerShell 或 Windows Explorer 右键菜单导入到本地 vault，并用 SQLite 记录每一次导入、去重、失败和撤销信息。
 
-当前版本：`v2.1.0`
+当前版本：`v2.1.1`
 
-- 下载地址：<https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0>
+- 下载地址：<https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1>
 - 英文 README：[README.md](README.md)
 
 ## 这个项目解决什么问题
@@ -35,7 +35,7 @@ C:\Users\<你>\Documents\KBIntakeVault
 
 ### 推荐方式
 
-1. 打开 [v2.1.0 Release 页面](https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0)。
+1. 打开 [v2.1.1 Release 页面](https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1)。
 2. 下载 `KBIntake-Setup.exe`。
 3. 运行安装包。
 4. 打开新的 PowerShell，执行：

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,7 +7,7 @@ This guide is for Windows users who want KBIntake installed for Explorer right-c
 1. Open the release page:
 
 ```text
-https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0
+https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1
 ```
 
 2. Download `KBIntake-Setup.exe`.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,15 +1,15 @@
 # KBIntake Project Status
 
-Last updated: 2026-05-03
+Last updated: 2026-05-06
 
 ## Summary
 
-KBIntake v2.1.0 is the latest release on branch `v2.0`. All planned features across Phase 1–3 are implemented, plus post-handoff additions (system tray, directory structure preservation, stale manifest handling). v2.1.0 fixed `--tags` frontmatter injection and added tray auto-start to the installer.
+KBIntake v2.1.1 is the latest release on branch `v2.0`. All planned features across Phase 1–3 are implemented, plus post-handoff additions (system tray, directory structure preservation, stale manifest handling). v2.1.1 fixed `--tags` frontmatter injection and added tray auto-start to the installer.
 
 Current release:
 
 ```text
-https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0
+https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1
 ```
 
 ## What Is Complete
@@ -125,7 +125,7 @@ https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0
 - GHA validation workflow for registry operations
 - Validated on Windows 11 physical hardware
 
-#### Default Templates (v2.1.0)
+#### Default Templates (v2.1.1)
 
 - 5 built-in templates (inbox, notes, documents, media, code) generated on first run
 - 4 routing rules matching common file extensions to templates
@@ -159,7 +159,7 @@ cargo build --release --locked --bins          # kbintake + kbintakew
 
 ## Release History
 
-- `v2.1.0` (2026-05-03) — Fix `--tags` frontmatter injection, tray autostart in installer, winget 2.0.0 manifest, default templates for first-run experience
+- `v2.1.1` (2026-05-03) — Fix `--tags` frontmatter injection, tray autostart in installer, winget 2.0.0 manifest, default templates for first-run experience
 - `v2.0.0` (2026-04-30) — Templates, Watch Mode, TUI, localization, Win11 context menu, system tray
 - `v1.0.1` — Static CRT, installer validation workflow
 - `v1.0.0` — Initial release

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,10 +4,10 @@ This roadmap tracks KBIntake after the `v1.0.0` Windows release.
 
 ## Current Release
 
-`v2.1.0` is the latest release. Previous releases: `v2.0.0`, `v1.0.1`, `v1.0.0`.
+`v2.1.1` is the latest release. Previous releases: `v2.0.0`, `v1.0.1`, `v1.0.0`.
 
 ```text
-https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.0
+https://github.com/GeziP/windows-rightclick-vault-import/releases/tag/v2.1.1
 ```
 
 The release includes:

--- a/installer/kbintake.nsi
+++ b/installer/kbintake.nsi
@@ -8,7 +8,7 @@
 !define APP_ICON "kbintake.ico"
 !define APP_COM_DLL "kbintake_com.dll"
 !define APP_COM_REG "kbintake-com-reg.exe"
-!define APP_VERSION "2.1.0"
+!define APP_VERSION "2.1.1"
 !define POWERSHELL_EXE "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
 
 Name "${APP_NAME}"

--- a/kbintake/Cargo.toml
+++ b/kbintake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbintake"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Windows-friendly CLI for right-click importing files into a local knowledge-base vault"
 


### PR DESCRIPTION
## Summary

- Bump version to v2.1.1
- Codex review fixes (COM command, object count, template persistence, nested watch)
- Updated docs and CHANGELOG

## Test plan

- [x] All 171 tests pass
- [x] Release workflow produced all artifacts
- [x] COM DLL Validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)