### PR TITLE
Add winget manifest for v2.1.1

### DIFF
--- a/installer/winget/2.1.1/GeziP.KBIntake.installer.yaml
+++ b/installer/winget/2.1.1/GeziP.KBIntake.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 2.1.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+ReleaseDate: 2026-05-06
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/GeziP/windows-rightclick-vault-import/releases/download/v2.1.1/KBIntake-Setup.exe
+    InstallerSha256: 91a4ec7a84030438174c3f066b8f09f288020d3ee7f65ef7de55cec1d4ba9ef7
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/installer/winget/2.1.1/GeziP.KBIntake.locale.en-US.yaml
+++ b/installer/winget/2.1.1/GeziP.KBIntake.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: GeziP
+PublisherUrl: https://github.com/GeziP
+PackageName: KBIntake
+PackageUrl: https://github.com/GeziP/windows-rightclick-vault-import
+Moniker: kbintake
+License: Proprietary
+ShortDescription: Windows-friendly local vault importer with Explorer integration and templates.
+Description: KBIntake imports files and folders into a local knowledge-base vault from PowerShell or the Windows Explorer right-click menu. Features include import templates, watch mode, TUI settings, and Obsidian integration.
+Tags:
+  - knowledge-base
+  - obsidian
+  - windows
+  - cli
+  - templates
+  - watch-mode
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/installer/winget/2.1.1/GeziP.KBIntake.yaml
+++ b/installer/winget/2.1.1/GeziP.KBIntake.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GeziP.KBIntake
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

- Add winget manifest directory `installer/winget/2.1.1/` with correct SHA256 hash for the release installer
- Manifest validated with `winget validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)